### PR TITLE
ci: fix release metadata check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: python -m pip install build pytest twine
 
       - name: Check release metadata
-        run: python -m pytest tests/test_release_metadata.py -q
+        run: python -m pytest tests/test_release_metadata.py -q -o addopts=''
 
       - name: Build distributions
         run: python -m build


### PR DESCRIPTION
## Summary
- run the release metadata test without the repository-wide coverage addopts
- keep the release build dependency set focused on build, pytest, and twine

## Verification
- `python -m pytest tests/test_release_metadata.py -q -o addopts=""`
- `python -m build`
- `python -m twine check dist/*`

Closes #2