### PR TITLE
feat: add peS2o Chroma stress harness

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
 language: en-US
 tone_instructions: "Be concise, evidence-focused, and privacy-aware. Prioritize correctness, security, test coverage, and local-first data handling."
 
@@ -13,11 +15,10 @@ reviews:
     - "!reports/**"
     - "!dist/**"
     - "!build/**"
-
-path_instructions:
-  - path: "src/alcove_dux/**"
-    instructions: "Focus on privacy boundaries, report-safe IDs, deterministic behavior, and benchmarkable evidence quality."
-  - path: "docs/**"
-    instructions: "Flag any private paths, private infrastructure names, raw document text, or unsupported misconduct-decision language."
-  - path: "tests/**"
-    instructions: "Prefer focused tests that cover privacy, offsets, calibration, and false-positive behavior."
+  path_instructions:
+    - path: "src/alcove_dux/**"
+      instructions: "Focus on privacy boundaries, report-safe IDs, deterministic behavior, and benchmarkable evidence quality."
+    - path: "docs/**"
+      instructions: "Flag any private paths, private infrastructure names, raw document text, or unsupported misconduct-decision language."
+    - path: "tests/**"
+      instructions: "Prefer focused tests that cover privacy, offsets, calibration, and false-positive behavior."

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -42,6 +42,69 @@ python scripts/calibrate_threshold.py --dataset plagbench --limit 1000
 
 Generated reports are written under `reports/live-fire/` and are intended to stay local unless deliberately summarized for publication.
 
+## Large peS2o Chroma Stress Runs
+
+The peS2o batch harness indexes bounded slices into Chroma, writes checkpoint
+state, and exits. Re-running the same command resumes from `next_shard` and
+`next_line`.
+
+```bash
+python scripts/pes2o_chroma_batch.py \
+  --run-id pes2o-train-1m-bge-chroma-batched \
+  --target-passages 1000000 \
+  --batch-passages 25000 \
+  --flush-size 512 \
+  --max-seconds 600 \
+  --hf-cache /path/to/hf-cache \
+  --device cuda
+```
+
+For inspection-only planning, print the next slice without loading Chroma or an
+embedding model:
+
+```bash
+python scripts/pes2o_chroma_batch.py --plan-only
+```
+
+Useful controls for bounded stress runs:
+
+- `--batch-passages`: limits how many passages one invocation indexes.
+- `--flush-size`: controls the Chroma upsert chunk size.
+- `--max-seconds`: asks the process to checkpoint and exit after a time budget.
+- `--gpu-max-temp-c`: pauses before indexing when `nvidia-smi` reports a hot GPU.
+- `--max-upsert-seconds`: flags slow Chroma persistence after a completed batch.
+- `--min-passages-per-second`: flags low total throughput after a completed batch.
+- `--collection-shard-size`: writes into suffixed Chroma collections once a shard
+  reaches the configured size.
+
+For large Chroma stress tests, collection sharding can keep later batches easier
+to inspect:
+
+```bash
+python scripts/pes2o_chroma_batch.py \
+  --run-id pes2o-train-1m-bge-chroma-batched \
+  --target-passages 1000000 \
+  --batch-passages 5000 \
+  --flush-size 2048 \
+  --collection-shard-size 250000 \
+  --max-seconds 240 \
+  --max-upsert-seconds 75 \
+  --min-passages-per-second 80 \
+  --hf-cache /path/to/hf-cache \
+  --device cuda
+```
+
+The base Chroma collection counts as shard 0. Later writes go to suffixed
+collections such as `pes2o_train_bge_small_shard_0001`. Retrieval over sharded
+Chroma collections should query each collection and merge the top-k hits.
+
+One completed 1M-passage peS2o stress run using this harness reported
+`target_reached` with 630,000 records in the base collection, 250,000 records in
+`pes2o_train_bge_small_shard_0001`, and 120,000 records in
+`pes2o_train_bge_small_shard_0002`. The run reported about 86 minutes of summed
+batch wall time excluding manual inspection pauses, and a local vectorstore size
+of about 2.33 GiB.
+
 ## Interpretation
 
 Benchmark scores are similarity evidence, not document-level plagiarism labels. Include the dataset, split, sample size, model ID, thresholds, and command when publishing results.

--- a/scripts/pes2o_chroma_batch.py
+++ b/scripts/pes2o_chroma_batch.py
@@ -1,0 +1,786 @@
+"""Index peS2o passages into Chroma in short, resumable batches.
+
+This script is intentionally process-bounded. Each invocation indexes the next
+slice of peS2o, writes state/progress JSON, and exits so local machines can run
+large Chroma indexing jobs in resumable steps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+import shutil
+import subprocess
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RUN_ID = "pes2o-train-1m-bge-chroma-batched"
+DEFAULT_MODEL_ID = "BAAI/bge-small-en-v1.5"
+DEFAULT_COLLECTION = "pes2o_train_bge_small"
+DEFAULT_TARGET_PASSAGES = 1_000_000
+DEFAULT_BATCH_PASSAGES = 25_000
+DEFAULT_FLUSH_SIZE = 512
+DEFAULT_MAX_SECONDS = 600
+DEFAULT_GPU_MAX_TEMP_C = 82.0
+DEFAULT_TOTAL_SHARDS = 20
+DATASET_ID = "allenai/peS2o:v2-train"
+
+WORD_RE = re.compile(r"\b[\w'-]+\b")
+
+
+@dataclass(frozen=True)
+class ScanPosition:
+    """Next dataset row to scan."""
+
+    shard: int
+    line: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {"next_shard": self.shard, "next_line": self.line}
+
+
+@dataclass(frozen=True)
+class Passage:
+    """A passage plus resumable source position."""
+
+    id: str
+    text: str
+    source: str
+    shard: int
+    line: int
+    next_position: ScanPosition
+
+
+class Pes2oScanner:
+    """Streaming peS2o scanner that remembers the latest line position."""
+
+    def __init__(
+        self,
+        *,
+        start: ScanPosition,
+        total_shards: int,
+        cache_dir: Path | None,
+    ) -> None:
+        self.position = start
+        self.total_shards = total_shards
+        self.cache_dir = cache_dir
+        self.lines_scanned = 0
+        self.short_passages_skipped = 0
+        self.exhausted = False
+
+    def __iter__(self):
+        from huggingface_hub import hf_hub_download
+
+        for shard in range(self.position.shard, self.total_shards):
+            start_line = self.position.line if shard == self.position.shard else 0
+            filename = f"data/v2/train-{shard:05d}-of-{self.total_shards:05d}.json.gz"
+            path = hf_hub_download(
+                "allenai/peS2o",
+                filename=filename,
+                repo_type="dataset",
+                cache_dir=str(self.cache_dir) if self.cache_dir else None,
+            )
+            with gzip.open(path, "rt", encoding="utf-8") as handle:
+                for line_number, line in enumerate(handle):
+                    if line_number < start_line:
+                        continue
+                    self.lines_scanned += 1
+                    next_position = ScanPosition(shard=shard, line=line_number + 1)
+                    self.position = next_position
+                    row = json.loads(line)
+                    text = first_passage(str(row.get("text", "")))
+                    if text is None:
+                        self.short_passages_skipped += 1
+                        continue
+                    source = str(row.get("source", "unknown"))[:80] or "unknown"
+                    passage_id = f"pes2o-train-{shard:05d}-{line_number:09d}"
+                    yield Passage(
+                        id=passage_id,
+                        text=text,
+                        source=source,
+                        shard=shard,
+                        line=line_number,
+                        next_position=next_position,
+                    )
+            self.position = ScanPosition(shard=shard + 1, line=0)
+        self.exhausted = True
+        self.position = ScanPosition(shard=self.total_shards, line=0)
+
+
+def main() -> int:
+    args = parse_args()
+    return run(args)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Batch peS2o train passages into Chroma")
+    parser.add_argument("--run-id", default=DEFAULT_RUN_ID)
+    parser.add_argument("--out-root", type=Path, default=Path("reports/live-fire"))
+    parser.add_argument("--index-root", type=Path, default=Path("vectorstores"))
+    parser.add_argument("--hf-cache", type=Path, help="Hugging Face cache directory")
+    parser.add_argument("--model-id", default=DEFAULT_MODEL_ID)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--collection-name", default=DEFAULT_COLLECTION)
+    parser.add_argument(
+        "--collection-shard-size",
+        type=int,
+        help=(
+            "Maximum records per Chroma collection. When set, the base collection "
+            "counts as shard 0 and later writes go to suffixed shard collections."
+        ),
+    )
+    parser.add_argument("--target-passages", type=int, default=DEFAULT_TARGET_PASSAGES)
+    parser.add_argument("--batch-passages", type=int, default=DEFAULT_BATCH_PASSAGES)
+    parser.add_argument("--flush-size", type=int, default=DEFAULT_FLUSH_SIZE)
+    parser.add_argument("--max-seconds", type=int, default=DEFAULT_MAX_SECONDS)
+    parser.add_argument(
+        "--max-upsert-seconds",
+        type=float,
+        help="Mark the batch as a guardrail stop when Chroma upserts exceed this many seconds",
+    )
+    parser.add_argument(
+        "--min-passages-per-second",
+        type=float,
+        help="Mark the batch as a guardrail stop when total throughput falls below this value",
+    )
+    parser.add_argument("--total-shards", type=int, default=DEFAULT_TOTAL_SHARDS)
+    parser.add_argument("--gpu-max-temp-c", type=float, default=DEFAULT_GPU_MAX_TEMP_C)
+    parser.add_argument("--no-gpu-temp-check", action="store_true")
+    parser.add_argument(
+        "--fresh",
+        action="store_true",
+        help="Delete this run's report state and vectorstore before starting",
+    )
+    parser.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="Print the next-batch plan without loading models or touching Chroma",
+    )
+    return parser.parse_args()
+
+
+def run(args: argparse.Namespace) -> int:
+    validate_positive_args(args)
+    out_dir = args.out_root / args.run_id
+    index_dir = args.index_root / args.run_id
+    state_path = out_dir / "state.json"
+    latest_path = out_dir / "latest.json"
+
+    if args.plan_only:
+        state = load_state(state_path, args=args, index_dir=index_dir)
+        plan = next_batch_plan(state, args=args, index_dir=index_dir)
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return 0
+
+    if args.fresh:
+        reset_run(out_dir=out_dir, index_dir=index_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    state = load_state(state_path, args=args, index_dir=index_dir)
+
+    temp = current_gpu_temp_c() if not args.no_gpu_temp_check else None
+    if temp is not None and temp >= args.gpu_max_temp_c:
+        report = finish_without_indexing(
+            state,
+            status="temperature_pause",
+            note=f"GPU temperature {temp:.1f}C is at or above limit {args.gpu_max_temp_c:.1f}C.",
+            args=args,
+            index_dir=index_dir,
+            extra={"gpu_temp_c": temp},
+        )
+        write_report_files(out_dir, state_path, latest_path, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    try:
+        import chromadb
+        from sentence_transformers import SentenceTransformer
+    except ImportError as exc:
+        raise SystemExit(
+            'peS2o Chroma batching requires: python -m pip install -e ".[semantic,vector-chroma]"'
+        ) from exc
+
+    started = time.perf_counter()
+    model = SentenceTransformer(args.model_id, device=args.device)
+    client = chromadb.PersistentClient(path=str(index_dir))
+    shard_counts = collection_shard_counts(client, args.collection_name)
+    collection = select_active_collection(client, args, shard_counts)
+    active_collection_name = collection.name
+    count_before = sum(shard_counts.values())
+    if count_before >= args.target_passages:
+        report = finish_without_indexing(
+            state,
+            status="target_reached",
+            note="Chroma collection already meets the target passage count.",
+            args=args,
+            index_dir=index_dir,
+            extra={"collection_count_before": count_before},
+        )
+        write_report_files(out_dir, state_path, latest_path, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    start = ScanPosition(
+        shard=int(state.get("next_shard", 0)),
+        line=int(state.get("next_line", 0)),
+    )
+    scanner = Pes2oScanner(start=start, total_shards=args.total_shards, cache_dir=args.hf_cache)
+    pending: list[Passage] = []
+    source_counts: Counter[str] = Counter()
+    indexed_this_run = 0
+    embed_seconds = 0.0
+    upsert_seconds = 0.0
+    status = "batch_complete"
+    stop_note = ""
+    batch_number = int(state.get("batch_number", 0)) + 1
+    last_flush_position = start
+
+    def rotate_active_collection_if_needed() -> None:
+        nonlocal collection, active_collection_name
+        if args.collection_shard_size is None:
+            return
+        active_count = shard_counts.get(active_collection_name, 0)
+        if active_count < args.collection_shard_size:
+            return
+        collection = select_active_collection(client, args, shard_counts)
+        active_collection_name = collection.name
+
+    def flush_pending() -> bool:
+        nonlocal embed_seconds, upsert_seconds, indexed_this_run, last_flush_position, status
+        if not pending:
+            return True
+        while pending:
+            rotate_active_collection_if_needed()
+            temp_before = current_gpu_temp_c() if not args.no_gpu_temp_check else None
+            if temp_before is not None and temp_before >= args.gpu_max_temp_c:
+                status = "temperature_pause"
+                return False
+            chunk_size = len(pending)
+            if args.collection_shard_size is not None:
+                remaining_in_shard = args.collection_shard_size - shard_counts.get(
+                    active_collection_name,
+                    0,
+                )
+                chunk_size = min(chunk_size, max(1, remaining_in_shard))
+            chunk = pending[:chunk_size]
+            texts = [item.text for item in chunk]
+            t0 = time.perf_counter()
+            vectors = model.encode(
+                prepare_embedding_texts(args.model_id, texts, role="passage"),
+                normalize_embeddings=True,
+                batch_size=min(128, len(texts)),
+                show_progress_bar=False,
+            )
+            embed_seconds += time.perf_counter() - t0
+            embeddings = vectors.tolist() if hasattr(vectors, "tolist") else list(vectors)
+            t1 = time.perf_counter()
+            collection.upsert(
+                ids=[item.id for item in chunk],
+                embeddings=embeddings,
+                metadatas=[
+                    {
+                        "document_id": item.id,
+                        "chunk_id": f"{item.id}:0",
+                        "source": item.source,
+                        "start": 0,
+                        "end": len(item.text),
+                        "shard": item.shard,
+                        "line": item.line,
+                    }
+                    for item in chunk
+                ],
+            )
+            upsert_seconds += time.perf_counter() - t1
+            shard_counts[active_collection_name] = int(collection.count())
+            indexed_this_run += len(chunk)
+            last_flush_position = chunk[-1].next_position
+            del pending[:chunk_size]
+            interim = make_report(
+                state,
+                args=args,
+                index_dir=index_dir,
+                batch_number=batch_number,
+                status="running",
+                collection_count_before=count_before,
+                collection_count_after=sum(shard_counts.values()),
+                indexed_this_run=indexed_this_run,
+                lines_scanned=scanner.lines_scanned,
+                short_passages_skipped=scanner.short_passages_skipped,
+                source_counts=source_counts,
+                embed_seconds=embed_seconds,
+                upsert_seconds=upsert_seconds,
+                elapsed_seconds=time.perf_counter() - started,
+                next_position=last_flush_position,
+                note="Progress checkpoint after a successful Chroma upsert.",
+                active_collection_name=active_collection_name,
+                shard_counts=shard_counts,
+            )
+            write_json_atomic(state_path, state_from_report(interim))
+            write_json_atomic(latest_path, interim)
+        return True
+
+    for passage in scanner:
+        if indexed_this_run + len(pending) >= args.batch_passages:
+            break
+        if count_before + indexed_this_run + len(pending) >= args.target_passages:
+            status = "target_reached"
+            break
+        if pending and time.perf_counter() - started >= args.max_seconds:
+            status = "time_budget_reached"
+            stop_note = "Time budget reached; flushing pending records before exit."
+            break
+        pending.append(passage)
+        source_counts[passage.source] += 1
+        if len(pending) >= args.flush_size and not flush_pending():
+            stop_note = "GPU temperature limit reached before the next flush."
+            break
+        if time.perf_counter() - started >= args.max_seconds:
+            status = "time_budget_reached"
+            stop_note = "Time budget reached after the latest successful flush."
+            break
+
+    if pending and status != "temperature_pause":
+        flush_pending()
+
+    if scanner.exhausted:
+        status = "dataset_exhausted"
+        last_flush_position = scanner.position
+    shard_counts[active_collection_name] = int(collection.count())
+    count_after = sum(shard_counts.values())
+    final_elapsed = time.perf_counter() - started
+    passages_per_second = indexed_this_run / final_elapsed if indexed_this_run else 0.0
+    if count_after >= args.target_passages:
+        status = "target_reached"
+    elif args.max_upsert_seconds is not None and upsert_seconds > args.max_upsert_seconds:
+        status = "upsert_guardrail_exceeded"
+        stop_note = (
+            f"Chroma upsert time {upsert_seconds:.3f}s exceeded guardrail "
+            f"{args.max_upsert_seconds:.3f}s."
+        )
+    elif (
+        args.min_passages_per_second is not None
+        and indexed_this_run
+        and passages_per_second < args.min_passages_per_second
+    ):
+        status = "throughput_guardrail_exceeded"
+        stop_note = (
+            f"Total throughput {passages_per_second:.2f}/sec fell below guardrail "
+            f"{args.min_passages_per_second:.2f}/sec."
+        )
+    elif indexed_this_run >= args.batch_passages and status == "batch_complete":
+        stop_note = "Batch passage limit reached."
+    elif status == "batch_complete" and indexed_this_run == 0:
+        status = "no_progress"
+        stop_note = "No new passages were indexed in this invocation."
+
+    report = make_report(
+        state,
+        args=args,
+        index_dir=index_dir,
+        batch_number=batch_number,
+        status=status,
+        collection_count_before=count_before,
+        collection_count_after=count_after,
+        indexed_this_run=indexed_this_run,
+        lines_scanned=scanner.lines_scanned,
+        short_passages_skipped=scanner.short_passages_skipped,
+        source_counts=source_counts,
+        embed_seconds=embed_seconds,
+        upsert_seconds=upsert_seconds,
+        elapsed_seconds=time.perf_counter() - started,
+        next_position=last_flush_position,
+        note=stop_note or status_note(status),
+        active_collection_name=active_collection_name,
+        shard_counts=shard_counts,
+    )
+    write_report_files(out_dir, state_path, latest_path, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+def validate_positive_args(args: argparse.Namespace) -> None:
+    for name in ("target_passages", "batch_passages", "flush_size", "max_seconds", "total_shards"):
+        if int(getattr(args, name)) <= 0:
+            raise SystemExit(f"--{name.replace('_', '-')} must be positive")
+    if args.collection_shard_size is not None and args.collection_shard_size <= 0:
+        raise SystemExit("--collection-shard-size must be positive")
+
+
+def collection_shard_name(base_name: str, shard_index: int) -> str:
+    """Return the Chroma collection name for a logical shard."""
+
+    if shard_index == 0:
+        return base_name
+    return f"{base_name}_shard_{shard_index:04d}"
+
+
+def collection_shard_index(base_name: str, collection_name: str) -> int | None:
+    """Return the shard index for a collection name, if it belongs to the shard set."""
+
+    if collection_name == base_name:
+        return 0
+    prefix = f"{base_name}_shard_"
+    if not collection_name.startswith(prefix):
+        return None
+    suffix = collection_name.removeprefix(prefix)
+    if not re.fullmatch(r"\d{4}", suffix):
+        return None
+    return int(suffix)
+
+
+def collection_names(client: Any) -> list[str]:
+    """Return collection names across Chroma versions."""
+
+    names = []
+    for item in client.list_collections():
+        names.append(str(item if isinstance(item, str) else item.name))
+    return names
+
+
+def collection_shard_counts(client: Any, base_name: str) -> dict[str, int]:
+    """Count existing collections that belong to the configured shard set."""
+
+    counts: dict[str, int] = {}
+    for name in collection_names(client):
+        if collection_shard_index(base_name, name) is None:
+            continue
+        counts[name] = int(client.get_collection(name).count())
+    return dict(
+        sorted(
+            counts.items(),
+            key=lambda item: collection_shard_index(base_name, item[0]) or 0,
+        )
+    )
+
+
+def select_active_collection(
+    client: Any,
+    args: argparse.Namespace,
+    shard_counts: dict[str, int],
+) -> Any:
+    """Return the collection that should receive the next upsert."""
+
+    if args.collection_shard_size is None:
+        collection = client.get_or_create_collection(
+            name=args.collection_name,
+            metadata={"hnsw:space": "cosine"},
+        )
+        shard_counts[args.collection_name] = int(collection.count())
+        return collection
+
+    shard_index = 0
+    while True:
+        name = collection_shard_name(args.collection_name, shard_index)
+        if shard_counts.get(name, 0) < args.collection_shard_size:
+            collection = client.get_or_create_collection(
+                name=name,
+                metadata={"hnsw:space": "cosine"},
+            )
+            shard_counts[name] = int(collection.count())
+            return collection
+        shard_index += 1
+
+
+def reset_run(*, out_dir: Path, index_dir: Path) -> None:
+    for path in (out_dir, index_dir):
+        resolved = path.resolve()
+        if resolved.anchor == str(resolved):
+            raise SystemExit(f"Refusing to delete root path: {path}")
+        if path.exists():
+            shutil.rmtree(path)
+
+
+def load_state(state_path: Path, *, args: argparse.Namespace, index_dir: Path) -> dict[str, Any]:
+    if state_path.exists():
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    return {
+        "run_id": args.run_id,
+        "dataset_id": DATASET_ID,
+        "model_id": args.model_id,
+        "device": args.device,
+        "collection_name": args.collection_name,
+        "collection_shard_size": args.collection_shard_size,
+        "index_dir": str(index_dir),
+        "target_passages": args.target_passages,
+        "batch_passages": args.batch_passages,
+        "flush_size": args.flush_size,
+        "total_shards": args.total_shards,
+        "next_shard": 0,
+        "next_line": 0,
+        "batch_number": 0,
+        "status": "new",
+        "created": utc_now(),
+        "updated": utc_now(),
+        "notes": [
+            "Aggregate metrics only; raw peS2o text is not emitted.",
+            "Each invocation is bounded and resumable via next_shard/next_line.",
+        ],
+    }
+
+
+def next_batch_plan(
+    state: dict[str, Any],
+    *,
+    args: argparse.Namespace,
+    index_dir: Path,
+) -> dict[str, Any]:
+    return {
+        "run_id": args.run_id,
+        "dataset_id": DATASET_ID,
+        "model_id": args.model_id,
+        "device": args.device,
+        "index_dir": str(index_dir),
+        "collection_name": args.collection_name,
+        "collection_shard_size": args.collection_shard_size,
+        "target_passages": args.target_passages,
+        "batch_passages": args.batch_passages,
+        "flush_size": args.flush_size,
+        "total_shards": args.total_shards,
+        "max_seconds": args.max_seconds,
+        "max_upsert_seconds": args.max_upsert_seconds,
+        "min_passages_per_second": args.min_passages_per_second,
+        "next_shard": int(state.get("next_shard", 0)),
+        "next_line": int(state.get("next_line", 0)),
+        "next_batch_number": int(state.get("batch_number", 0)) + 1,
+    }
+
+
+def finish_without_indexing(
+    state: dict[str, Any],
+    *,
+    status: str,
+    note: str,
+    args: argparse.Namespace,
+    index_dir: Path,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    position = ScanPosition(
+        shard=int(state.get("next_shard", 0)),
+        line=int(state.get("next_line", 0)),
+    )
+    report = make_report(
+        state,
+        args=args,
+        index_dir=index_dir,
+        batch_number=int(state.get("batch_number", 0)),
+        status=status,
+        collection_count_before=int(extra.get("collection_count_before", 0)) if extra else 0,
+        collection_count_after=int(extra.get("collection_count_before", 0)) if extra else 0,
+        indexed_this_run=0,
+        lines_scanned=0,
+        short_passages_skipped=0,
+        source_counts=Counter(),
+        embed_seconds=0.0,
+        upsert_seconds=0.0,
+        elapsed_seconds=0.0,
+        next_position=position,
+        note=note,
+        active_collection_name=args.collection_name,
+        shard_counts={args.collection_name: int(extra.get("collection_count_before", 0))}
+        if extra
+        else {},
+    )
+    if extra:
+        report.update(extra)
+    return report
+
+
+def make_report(
+    state: dict[str, Any],
+    *,
+    args: argparse.Namespace,
+    index_dir: Path,
+    batch_number: int,
+    status: str,
+    collection_count_before: int,
+    collection_count_after: int,
+    indexed_this_run: int,
+    lines_scanned: int,
+    short_passages_skipped: int,
+    source_counts: Counter[str],
+    embed_seconds: float,
+    upsert_seconds: float,
+    elapsed_seconds: float,
+    next_position: ScanPosition,
+    note: str,
+    active_collection_name: str,
+    shard_counts: dict[str, int],
+) -> dict[str, Any]:
+    return {
+        "run_id": args.run_id,
+        "dataset_id": DATASET_ID,
+        "license_note": "ODC-By per the Hugging Face dataset card.",
+        "status": status,
+        "note": note,
+        "batch_number": batch_number,
+        "created": state.get("created", utc_now()),
+        "updated": utc_now(),
+        "model_id": args.model_id,
+        "device": args.device,
+        "collection_name": args.collection_name,
+        "active_collection_name": active_collection_name,
+        "collection_shard_size": args.collection_shard_size,
+        "collection_shard_counts": dict(
+            sorted(
+                shard_counts.items(),
+                key=lambda item: collection_shard_index(args.collection_name, item[0]) or 0,
+            )
+        ),
+        "index_backend": "ChromaDB PersistentClient hnsw:space=cosine",
+        "index_dir": str(index_dir),
+        "target_passages": args.target_passages,
+        "batch_passages": args.batch_passages,
+        "flush_size": args.flush_size,
+        "total_shards": args.total_shards,
+        "max_seconds": args.max_seconds,
+        "max_upsert_seconds": args.max_upsert_seconds,
+        "min_passages_per_second": args.min_passages_per_second,
+        "collection_count_before": collection_count_before,
+        "collection_count_after": collection_count_after,
+        "indexed_this_run": indexed_this_run,
+        "remaining_to_target": max(0, args.target_passages - collection_count_after),
+        "lines_scanned_this_run": lines_scanned,
+        "short_passages_skipped_this_run": short_passages_skipped,
+        "next_shard": next_position.shard,
+        "next_line": next_position.line,
+        "embedding_seconds": round(embed_seconds, 3),
+        "upsert_seconds": round(upsert_seconds, 3),
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "passages_per_second_total": round(indexed_this_run / elapsed_seconds, 2)
+        if elapsed_seconds and indexed_this_run
+        else 0.0,
+        "passages_per_second_embedding_only": round(indexed_this_run / embed_seconds, 2)
+        if embed_seconds and indexed_this_run
+        else 0.0,
+        "source_distribution_top10": source_counts.most_common(10),
+        "notes": [
+            "Aggregate metrics only; raw peS2o text is not emitted.",
+            "Use the same command again to resume from next_shard/next_line.",
+            "The script exits after each bounded batch, time budget, target, or temperature stop.",
+        ],
+    }
+
+
+def state_from_report(report: dict[str, Any]) -> dict[str, Any]:
+    keys = (
+        "run_id",
+        "dataset_id",
+        "model_id",
+        "device",
+        "collection_name",
+        "active_collection_name",
+        "collection_shard_size",
+        "index_dir",
+        "target_passages",
+        "batch_passages",
+        "flush_size",
+        "max_upsert_seconds",
+        "min_passages_per_second",
+        "total_shards",
+        "next_shard",
+        "next_line",
+        "batch_number",
+        "status",
+        "created",
+        "updated",
+        "notes",
+    )
+    return {key: report[key] for key in keys if key in report}
+
+
+def write_report_files(
+    out_dir: Path,
+    state_path: Path,
+    latest_path: Path,
+    report: dict[str, Any],
+) -> None:
+    batch_path = out_dir / f"batch-{int(report['batch_number']):04d}.json"
+    write_json_atomic(state_path, state_from_report(report))
+    write_json_atomic(latest_path, report)
+    write_json_atomic(batch_path, report)
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def first_passage(text: str, *, max_words: int = 160) -> str | None:
+    paragraphs = [
+        paragraph.strip().replace("\n", " ")
+        for paragraph in text.split("\n\n")
+        if len(words(paragraph)) >= 80
+    ]
+    passage = paragraphs[0] if paragraphs else text.replace("\n", " ")
+    tokens = words(passage)
+    if len(tokens) < 80:
+        return None
+    return " ".join(tokens[:max_words])
+
+
+def words(text: str) -> list[str]:
+    return WORD_RE.findall(text)
+
+
+def prepare_embedding_texts(model_id: str, texts: list[str], *, role: str) -> list[str]:
+    if "multilingual-e5" not in model_id:
+        return texts
+    prefix = "query: " if role == "query" else "passage: "
+    return [f"{prefix}{text}" for text in texts]
+
+
+def current_gpu_temp_c() -> float | None:
+    try:
+        completed = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=temperature.gpu",
+                "--format=csv,noheader,nounits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    first = completed.stdout.strip().splitlines()[0] if completed.stdout.strip() else ""
+    try:
+        return float(first.strip())
+    except ValueError:
+        return None
+
+
+def status_note(status: str) -> str:
+    return {
+        "batch_complete": "Batch completed; run the same command again to continue.",
+        "target_reached": "Target passage count reached.",
+        "time_budget_reached": "Time budget reached; run the same command again to continue.",
+        "temperature_pause": "GPU temperature limit reached; resume after the system cools down.",
+        "throughput_guardrail_exceeded": (
+            "Batch completed, but throughput fell below the safety guardrail."
+        ),
+        "upsert_guardrail_exceeded": (
+            "Batch completed, but Chroma upsert time exceeded the safety guardrail."
+        ),
+        "dataset_exhausted": "All configured peS2o train shards were scanned.",
+        "no_progress": "No progress was made in this invocation.",
+    }.get(status, status)
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pes2o_chroma_batch.py
+++ b/scripts/pes2o_chroma_batch.py
@@ -345,10 +345,10 @@ def run(args: argparse.Namespace) -> int:
             stop_note = "Time budget reached after the latest successful flush."
             break
 
-    if pending and status != "temperature_pause":
-        flush_pending()
+    if pending and status != "temperature_pause" and not flush_pending():
+        stop_note = "GPU temperature limit reached before the next flush."
 
-    if scanner.exhausted:
+    if scanner.exhausted and status != "temperature_pause":
         status = "dataset_exhausted"
         last_flush_position = scanner.position
     shard_counts[active_collection_name] = int(collection.count())
@@ -731,7 +731,7 @@ def words(text: str) -> list[str]:
 
 
 def prepare_embedding_texts(model_id: str, texts: list[str], *, role: str) -> list[str]:
-    if "multilingual-e5" not in model_id:
+    if re.search(r"(^|/)(?:multilingual-)?e5", model_id, flags=re.IGNORECASE) is None:
         return texts
     prefix = "query: " if role == "query" else "passage: "
     return [f"{prefix}{text}" for text in texts]

--- a/tests/test_pes2o_chroma_batch.py
+++ b/tests/test_pes2o_chroma_batch.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from argparse import Namespace
+from collections import Counter
+from pathlib import Path
+
+
+def load_batch_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "pes2o_chroma_batch.py"
+    spec = importlib.util.spec_from_file_location("pes2o_chroma_batch", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def batch_args(**overrides):
+    defaults = {
+        "run_id": "unit-run",
+        "model_id": "BAAI/bge-small-en-v1.5",
+        "device": "cpu",
+        "collection_name": "pes2o_train_bge_small",
+        "collection_shard_size": None,
+        "target_passages": 1_000_000,
+        "batch_passages": 25_000,
+        "flush_size": 512,
+        "max_seconds": 600,
+        "max_upsert_seconds": None,
+        "min_passages_per_second": None,
+        "total_shards": 20,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_first_passage_requires_and_truncates_words():
+    module = load_batch_module()
+    assert module.first_passage("too short") is None
+
+    text = " ".join(f"word{i}" for i in range(100))
+    assert module.first_passage(text, max_words=80) == " ".join(f"word{i}" for i in range(80))
+
+
+def test_next_batch_plan_uses_resume_state(tmp_path):
+    module = load_batch_module()
+    args = batch_args(batch_passages=10_000, flush_size=256)
+    state = module.load_state(tmp_path / "missing.json", args=args, index_dir=tmp_path / "index")
+    state["next_shard"] = 3
+    state["next_line"] = 42
+    state["batch_number"] = 7
+
+    plan = module.next_batch_plan(state, args=args, index_dir=tmp_path / "index")
+
+    assert plan["next_shard"] == 3
+    assert plan["next_line"] == 42
+    assert plan["next_batch_number"] == 8
+    assert plan["batch_passages"] == 10_000
+    assert plan["flush_size"] == 256
+    assert plan["max_upsert_seconds"] is None
+    assert plan["min_passages_per_second"] is None
+    assert plan["collection_shard_size"] is None
+    assert plan["total_shards"] == 20
+
+
+def test_state_from_report_preserves_resume_cursor(tmp_path):
+    module = load_batch_module()
+    args = batch_args()
+    report = module.make_report(
+        {"created": "1970-01-01T00:00:00Z"},
+        args=args,
+        index_dir=tmp_path / "index",
+        batch_number=2,
+        status="batch_complete",
+        collection_count_before=25_000,
+        collection_count_after=50_000,
+        indexed_this_run=25_000,
+        lines_scanned=30_000,
+        short_passages_skipped=5_000,
+        source_counts=Counter({"pubmed": 10}),
+        embed_seconds=20.0,
+        upsert_seconds=40.0,
+        elapsed_seconds=80.0,
+        next_position=module.ScanPosition(shard=1, line=123),
+        note="done",
+        active_collection_name="pes2o_train_bge_small",
+        shard_counts={"pes2o_train_bge_small": 50_000},
+    )
+
+    state = module.state_from_report(report)
+
+    assert state["next_shard"] == 1
+    assert state["next_line"] == 123
+    assert state["batch_number"] == 2
+    assert state["status"] == "batch_complete"
+    assert state["total_shards"] == 20
+    assert state["max_upsert_seconds"] is None
+    assert state["min_passages_per_second"] is None
+    assert state["collection_shard_size"] is None
+
+
+def test_collection_shard_names_and_selection():
+    module = load_batch_module()
+
+    assert module.collection_shard_name("base", 0) == "base"
+    assert module.collection_shard_name("base", 2) == "base_shard_0002"
+    assert module.collection_shard_index("base", "base") == 0
+    assert module.collection_shard_index("base", "base_shard_0002") == 2
+    assert module.collection_shard_index("base", "other") is None
+
+
+def test_current_gpu_temp_ignores_missing_nvidia_smi(monkeypatch):
+    module = load_batch_module()
+
+    def raise_missing(*args, **kwargs):
+        raise FileNotFoundError("nvidia-smi")
+
+    monkeypatch.setattr(module.subprocess, "run", raise_missing)
+
+    assert module.current_gpu_temp_c() is None
+
+
+def test_prepare_embedding_texts_adds_e5_prefixes_only_for_e5_models():
+    module = load_batch_module()
+
+    assert module.prepare_embedding_texts("BAAI/bge-small", ["hello"], role="passage") == [
+        "hello"
+    ]
+    assert module.prepare_embedding_texts(
+        "intfloat/multilingual-e5-small",
+        ["hello"],
+        role="query",
+    ) == ["query: hello"]

--- a/tests/test_pes2o_chroma_batch.py
+++ b/tests/test_pes2o_chroma_batch.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
+import types
 from argparse import Namespace
 from collections import Counter
 from pathlib import Path
@@ -32,6 +34,13 @@ def batch_args(**overrides):
         "max_upsert_seconds": None,
         "min_passages_per_second": None,
         "total_shards": 20,
+        "gpu_max_temp_c": 82.0,
+        "no_gpu_temp_check": False,
+        "out_root": Path("reports/live-fire"),
+        "index_root": Path("vectorstores"),
+        "hf_cache": None,
+        "fresh": False,
+        "plan_only": False,
     }
     defaults.update(overrides)
     return Namespace(**defaults)
@@ -134,3 +143,88 @@ def test_prepare_embedding_texts_adds_e5_prefixes_only_for_e5_models():
         ["hello"],
         role="query",
     ) == ["query: hello"]
+    assert module.prepare_embedding_texts(
+        "intfloat/e5-base-v2",
+        ["hello"],
+        role="passage",
+    ) == ["passage: hello"]
+
+
+def test_temperature_pause_after_exhaustion_preserves_resume_cursor(
+    monkeypatch,
+    tmp_path,
+):
+    module = load_batch_module()
+
+    class FakeModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode(self, texts, **kwargs):
+            return [[0.1] for _ in texts]
+
+    class FakeCollection:
+        name = "pes2o_train_bge_small"
+
+        def count(self):
+            return 0
+
+        def upsert(self, **kwargs):
+            raise AssertionError("temperature pause should happen before upsert")
+
+    class FakeClient:
+        def list_collections(self):
+            return []
+
+        def get_or_create_collection(self, **kwargs):
+            return FakeCollection()
+
+    class ExhaustedScanner:
+        def __init__(self, *, start, total_shards, cache_dir):
+            self.position = start
+            self.lines_scanned = 0
+            self.short_passages_skipped = 0
+            self.exhausted = False
+
+        def __iter__(self):
+            self.lines_scanned = 1
+            yield module.Passage(
+                id="pes2o-train-00000-000000000",
+                text=" ".join(f"word{i}" for i in range(100)),
+                source="unit",
+                shard=0,
+                line=0,
+                next_position=module.ScanPosition(shard=0, line=1),
+            )
+            self.exhausted = True
+            self.position = module.ScanPosition(shard=1, line=0)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        types.SimpleNamespace(SentenceTransformer=FakeModel),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "chromadb",
+        types.SimpleNamespace(PersistentClient=lambda **kwargs: FakeClient()),
+    )
+    monkeypatch.setattr(module, "Pes2oScanner", ExhaustedScanner)
+    temps = iter([40.0, 90.0])
+    monkeypatch.setattr(module, "current_gpu_temp_c", lambda: next(temps))
+
+    args = batch_args(
+        out_root=tmp_path / "reports",
+        index_root=tmp_path / "index",
+        batch_passages=10,
+        flush_size=10,
+        total_shards=1,
+    )
+
+    assert module.run(args) == 0
+
+    latest = json.loads((tmp_path / "reports" / "unit-run" / "latest.json").read_text())
+    assert latest["status"] == "temperature_pause"
+    assert latest["next_shard"] == 0
+    assert latest["next_line"] == 0
+    assert latest["indexed_this_run"] == 0


### PR DESCRIPTION
## Summary
- port BLD’s batched peS2o Chroma stress harness into the public Alcove Dux tree
- add checkpoint/resume state, Chroma collection sharding, temperature and throughput guardrails, and plan-only mode
- document large peS2o Chroma stress runs with public-safe commands and aggregate-only result notes
- add unit coverage for planning, resume state, sharded collection naming, GPU temperature handling, and E5 text prefixes

## Verification
- `python -m pytest tests/test_pes2o_chroma_batch.py -q -o addopts=""`
- `python -m ruff check scripts/pes2o_chroma_batch.py tests/test_pes2o_chroma_batch.py`
- `python -m ruff check .`
- `python -m pytest -q`
- `python scripts/pes2o_chroma_batch.py --plan-only --device cpu --out-root /tmp/alcove-dux-pes2o-reports --index-root /tmp/alcove-dux-pes2o-vectorstores`

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resumable batch indexing with checkpoint support and status reporting.
  * Added operational flags for batch control, time budgeting, GPU temperature gating, and throughput validation.
  * Added plan-only mode to preview work without execution.
  * Added support for sharded collection indexing.

* **Documentation**
  * Added benchmark guidance with operational examples and instructions.

* **Tests**
  * Added comprehensive test coverage for indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->