### PR TITLE
ci: fix Scorecard workflow permissions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
 language: en-US
 tone_instructions: "Be concise, evidence-focused, and privacy-aware. Prioritize correctness, security, test coverage, and local-first data handling."
 
@@ -13,11 +15,10 @@ reviews:
     - "!reports/**"
     - "!dist/**"
     - "!build/**"
-
-path_instructions:
-  - path: "src/alcove_dux/**"
-    instructions: "Focus on privacy boundaries, report-safe IDs, deterministic behavior, and benchmarkable evidence quality."
-  - path: "docs/**"
-    instructions: "Flag any private paths, private infrastructure names, raw document text, or unsupported misconduct-decision language."
-  - path: "tests/**"
-    instructions: "Prefer focused tests that cover privacy, offsets, calibration, and false-positive behavior."
+  path_instructions:
+    - path: "src/alcove_dux/**"
+      instructions: "Focus on privacy boundaries, report-safe IDs, deterministic behavior, and benchmarkable evidence quality."
+    - path: "docs/**"
+      instructions: "Flag any private paths, private infrastructure names, raw document text, or unsupported misconduct-decision language."
+    - path: "tests/**"
+      instructions: "Prefer focused tests that cover privacy, offsets, calibration, and false-positive behavior."

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,19 +2,22 @@ name: OpenSSF Scorecard
 
 on:
   branch_protection_rule:
+  workflow_dispatch:
   schedule:
     - cron: "33 5 * * 2"
   push:
-    branches: ["develop"]
+    branches: ["develop", "main"]
 
 permissions:
   contents: read
-  id-token: write
-  security-events: write
 
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- keep Scorecard workflow-level permissions read-only
- move `id-token: write` and `security-events: write` to the Scorecard job
- add manual dispatch and run Scorecard on both `develop` and `main`

## Root Cause
OpenSSF Scorecard rejects published results when write permissions are declared at workflow level. The failing run reported: `global perm is set to write` for `security-events` and `id-token`.

## Verification
- parsed `.github/workflows/scorecard.yml` and asserted top-level/job-level permissions

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance security practices and support additional deployment triggers.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal infrastructure and security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->