### PR TITLE
chore: harden code scanning and upload errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["develop"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Python ${{ matrix.python-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,24 +10,26 @@ on:
     - cron: "21 4 * * 1"
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze Python
     if: vars.CODEQL_ENABLED == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,13 +9,15 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   semgrep:
     name: Optional Semgrep Scan
     if: github.event_name == 'workflow_dispatch' || vars.SEMGREP_ENABLED == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -34,6 +36,6 @@ jobs:
 
       - name: Upload SARIF
         if: always() && hashFiles('semgrep.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,12 @@ Alcove Dux is local-first and may process sensitive documents. Please report vul
 
 ## Reporting
 
-Open a private vulnerability report through GitHub Security Advisories when available, or contact the maintainers through the repository owner.
+Open a private vulnerability report through GitHub Security Advisories:
+
+- <https://github.com/Spitfire-Cowboy/alcove-dux/security/advisories/new>
+- <https://github.com/Spitfire-Cowboy/alcove-dux/security/policy>
+
+If GitHub private reporting is unavailable, contact the maintainers through the repository owner.
 
 Please include:
 

--- a/docs/repository-setup.md
+++ b/docs/repository-setup.md
@@ -28,6 +28,21 @@ stable release points after package and PyPI setup.
 - OpenSSF Scorecard: enabled for `develop` and scheduled runs.
 - Dependabot: configured for GitHub Actions and Python package updates.
 
+## Scorecard Follow-Up
+
+Some current Scorecard findings require maintainer or repository-governance follow-through rather
+than code-only changes:
+
+- `MaintainedID`: cannot clear until the repository is older than 90 days.
+- `CodeReviewID`: depends on reviewed pull request history accumulating over time.
+- `CIIBestPracticesID`: requires pursuing the OpenSSF Best Practices badge externally.
+- `FuzzingID`: requires adding a real fuzzing target and automation; this is feature work, not a
+  workflow-only fix.
+- `SecurityPolicyID`: keep `SECURITY.md` linked to GitHub private reporting and verify GitHub shows
+  the repository policy at `Security -> Policy`.
+- `PinnedDependenciesID`: Scorecard will continue to flag `pip install` commands in workflows and
+  the Dockerfile until the project adopts a reproducible lockfile or hashed-install strategy.
+
 ## PyPI
 
 Recommended publishing gate: review the package metadata, release workflow, and

--- a/src/alcove_dux/api.py
+++ b/src/alcove_dux/api.py
@@ -1,5 +1,6 @@
 """Optional FastAPI app for local Alcove Dux scans."""
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -12,6 +13,10 @@ from alcove_dux.documents import Document, load_document_file
 from alcove_dux.matching import compare_texts
 from alcove_dux.reports import ReportDocument, ScanReport
 from alcove_dux.storage import AlcoveDuxStore
+
+logger = logging.getLogger(__name__)
+SAFE_UPLOAD_ERROR_PREFIXES = ("Unsupported document type:",)
+GENERIC_UPLOAD_ERROR_MESSAGE = "Unable to process uploaded document."
 
 
 def create_app(database_path: str | Path | None = None):
@@ -86,10 +91,11 @@ def create_app(database_path: str | Path | None = None):
         try:
             document = await _document_from_upload(file, document_id=document_id or None)
         except (RuntimeError, ValueError) as error:
+            message = _handle_upload_error(error, filename=file.filename)
             return _dashboard_html(
                 store.list_documents(),
                 store.list_scans(),
-                message=str(error),
+                message=message,
             )
         metadata = dict(document.metadata)
         if title:
@@ -159,7 +165,10 @@ def create_app(database_path: str | Path | None = None):
         try:
             document = await _document_from_upload(file, document_id=document_id or None)
         except (RuntimeError, ValueError) as error:
-            raise HTTPException(status_code=400, detail=str(error)) from error
+            raise HTTPException(
+                status_code=400,
+                detail=_handle_upload_error(error, filename=file.filename),
+            ) from error
         if title:
             document = Document(
                 id=document.id,
@@ -566,6 +575,15 @@ async def _document_from_upload(file: Any, *, document_id: str | None) -> Docume
     finally:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)
+
+
+def _handle_upload_error(error: RuntimeError | ValueError, *, filename: str | None) -> str:
+    message = str(error)
+    if message.startswith(SAFE_UPLOAD_ERROR_PREFIXES):
+        logger.info("Rejected uploaded document", extra={"upload_name": filename or ""})
+        return message
+    logger.exception("Failed to process uploaded document", extra={"upload_name": filename or ""})
+    return GENERIC_UPLOAD_ERROR_MESSAGE
 
 
 def _document_row(document: dict) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import pytest
 
+import alcove_dux.api as api_module
 from alcove_dux.api import _dashboard_html, create_app
 
 
@@ -92,6 +93,26 @@ def test_api_file_upload_rejects_unsupported_type(tmp_path):
     assert uploaded.json()["detail"] == "Unsupported document type: .csv"
 
 
+def test_api_file_upload_hides_parser_errors(tmp_path, monkeypatch):
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    client = fastapi_testclient.TestClient(create_app(tmp_path / "reject-runtime.sqlite"))
+
+    async def fail_upload(*_args, **_kwargs):
+        raise RuntimeError("private parser path: /tmp/secret.txt")
+
+    monkeypatch.setattr(api_module, "_document_from_upload", fail_upload)
+
+    uploaded = client.post(
+        "/documents/file",
+        data={"document_id": "upload"},
+        files={"file": ("upload.txt", b"alpha", "text/plain")},
+    )
+
+    assert uploaded.status_code == 400
+    assert uploaded.json()["detail"] == api_module.GENERIC_UPLOAD_ERROR_MESSAGE
+    assert "secret.txt" not in uploaded.text
+
+
 def test_dashboard_routes_do_not_expose_raw_text(tmp_path):
     fastapi_testclient = pytest.importorskip("fastapi.testclient")
     client = fastapi_testclient.TestClient(create_app(tmp_path / "dashboard.sqlite"))
@@ -142,6 +163,26 @@ def test_dashboard_file_upload_error_stays_on_dashboard(tmp_path):
     assert uploaded.status_code == 200
     assert "Unsupported document type: .csv" in uploaded.text
     assert "not,a,supported,document" not in uploaded.text
+
+
+def test_dashboard_file_upload_hides_parser_errors(tmp_path, monkeypatch):
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    client = fastapi_testclient.TestClient(create_app(tmp_path / "dashboard-runtime.sqlite"))
+
+    async def fail_upload(*_args, **_kwargs):
+        raise RuntimeError("private parser path: /tmp/secret.txt")
+
+    monkeypatch.setattr(api_module, "_document_from_upload", fail_upload)
+
+    uploaded = client.post(
+        "/ui/documents/file",
+        data={"document_id": "upload"},
+        files={"file": ("upload.txt", b"alpha", "text/plain")},
+    )
+
+    assert uploaded.status_code == 200
+    assert api_module.GENERIC_UPLOAD_ERROR_MESSAGE in uploaded.text
+    assert "secret.txt" not in uploaded.text
 
 
 def test_dashboard_html_has_screen_reader_landmarks_and_labels():


### PR DESCRIPTION
## Summary
- harden GitHub Actions permissions for CI, CodeQL, Semgrep, and Scorecard
- fold the open `github/codeql-action` v4 update into this branch
- stop exposing parser/runtime upload errors to API and dashboard clients while preserving safe validation messages
- document the remaining Scorecard findings that still require repo/process follow-up

## Testing
- `python3 -m pytest tests/test_api.py tests/test_release_metadata.py -q`
- YAML parse check for `.coderabbit.yaml` and `.github/workflows/*.yml`
- `ruff check src/alcove_dux/api.py tests/test_api.py` in `.context/verify-venv`

## Notes
- Fixes #8
- Supersedes #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Document upload error messages now provide user-friendly information instead of technical details.

* **Documentation**
  * Enhanced security vulnerability reporting guidance with direct links for private advisory reporting.
  * Added Scorecard follow-up documentation covering maintainer responsibilities.

* **Chores**
  * Updated CI/CD workflows and security configurations for improved reliability and protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->