### PR TITLE
fix: disable scorecard result publication

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,9 +29,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
 
       - name: Upload SARIF
+        if: always() && hashFiles('results.sarif') != ''
         uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- disable Scorecard's separate result publication step, which is failing workflow verification against pinned action SHAs
- keep SARIF generation and always upload `results.sarif` to GitHub code scanning

## Notes
- The previous run already showed `Pinned-Dependencies` scoring 10/10 inside Scorecard.
- The failure was in Scorecard webapp publication, not in the dependency pinning itself.
