### PR TITLE
chore: fix CodeRabbit config on develop

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 language: en-US
-tone_instructions: "Be concise, evidence-focused, and privacy-aware. Prioritize correctness, security, test coverage, and local-first data handling."
+tone_instructions: "Be concise, evidence-focused, and privacy-aware. Prioritize correctness, security, test coverage, and local-first data handling. In src/alcove_dux, focus on privacy boundaries, report-safe IDs, deterministic behavior, and benchmarkable evidence quality. In docs, flag any private paths, private infrastructure names, raw document text, or unsupported misconduct-decision language. In tests, prefer focused tests that cover privacy, offsets, calibration, and false-positive behavior."
 
 reviews:
   profile: chill
@@ -15,10 +15,3 @@ reviews:
     - "!reports/**"
     - "!dist/**"
     - "!build/**"
-  path_instructions:
-    - path: "src/alcove_dux/**"
-      instructions: "Focus on privacy boundaries, report-safe IDs, deterministic behavior, and benchmarkable evidence quality."
-    - path: "docs/**"
-      instructions: "Flag any private paths, private infrastructure names, raw document text, or unsupported misconduct-decision language."
-    - path: "tests/**"
-      instructions: "Prefer focused tests that cover privacy, offsets, calibration, and false-positive behavior."


### PR DESCRIPTION
## Summary
- remove unsupported CodeRabbit path_instructions config
- fold the same review guidance into tone_instructions
- keep the existing path filters intact

## Verification
- config-only change
- rechecked repo security status: Dependabot 0 open, code scanning 0 open
