### PR TITLE
docs: add AI-use stigma note for review workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Alcove Dux is a review aid, not an automated misconduct decision system. It help
 ## 📚 Documentation
 
 - [Research Notes](docs/research.md) and [Benchmarks](docs/benchmarks.md)
+- [AI-use stigma note](docs/research-ai-use-stigma.md): why self-reported AI use is biased in education and what that changes for Alcove Dux.
 - [Configuration](docs/configuration.md), [Datasets](docs/datasets.md), and [Multilingual Detection](docs/multilingual.md)
 - [Vector Stores](docs/vector-stores.md) and [Alcove Plugin Plan](docs/alcove-plugin.md)
 - [Deployment Notes](docs/deployment.md), [Hosted Hardening](docs/hosted-hardening.md), and [Repository Setup](docs/repository-setup.md)

--- a/docs/research-ai-use-stigma.md
+++ b/docs/research-ai-use-stigma.md
@@ -1,0 +1,104 @@
+# AI-use stigma, underreporting, and what it means for Alcove Dux
+
+A recent paper, *Underreporting of AI Use: The Role of Social Desirability Bias* (SSRN 5464215), argues that self-reported AI use is systematically distorted in high-stigma settings.
+
+In the paper's educational sample, roughly 60% of students reported using AI themselves while roughly 90% reported that their peers use AI. In a follow-up survey, most respondents attributed the gap to embarrassment and social desirability rather than honest disagreement about actual usage.
+
+## Why this matters for Alcove Dux
+
+Alcove Dux operates in exactly the kind of setting where this distortion matters:
+
+- students may underreport AI assistance because they fear accusations of cheating or laziness
+- instructors may overestimate or underestimate AI use based on local norms, recent incidents, or moral panic
+- institutional surveys about AI use are not reliable ground truth for product calibration or policy design
+
+This reinforces the core Alcove Dux posture:
+
+- evidence first
+- local review first
+- reviewer judgment over binary accusations
+
+## Product implications
+
+### 1. Prefer evidence over confession
+
+Alcove Dux should never depend on students truthfully confessing how they used AI.
+
+The product should help reviewers inspect:
+
+- source overlap
+- paraphrase cues
+- mixed human/AI boundary signals
+- reviewer notes and policy context
+
+It should avoid framing that implies the software can determine guilt on its own.
+
+### 2. Treat declared AI use as biased metadata
+
+If a teacher, student, or institution reports whether AI was used, that input can still be useful, but it should be treated as context rather than clean labels.
+
+That matters for:
+
+- benchmark interpretation
+- calibration datasets
+- evaluation claims
+- institutional reporting dashboards
+
+### 3. Use mixed-provenance language
+
+The paper's results are a reminder that shame-heavy environments reward overconfident labels.
+
+Copy and UX should prefer:
+
+- `similarity evidence`
+- `possible paraphrase`
+- `mixed human/AI boundary`
+- `needs review`
+
+And should avoid:
+
+- `caught`
+- `proved`
+- `cheated`
+- `AI verdict`
+
+### 4. Research the norm gap directly
+
+When Alcove Dux does user research, ask both direct and indirect questions.
+
+Examples:
+
+- How often do your students disclose AI use?
+- How often do you think students in your department use AI assistance?
+- How often do other instructors in your institution believe AI use is acceptable?
+
+The gap between own-report and peer-report is often more informative than either answer alone.
+
+### 5. Keep privacy and local control central
+
+The more stigma-heavy the environment, the more important it is that review artifacts stay under local institutional control.
+
+That means local-first operation, explicit trust boundaries, and conservative exports are not just privacy features; they also reduce the pressure that distorts measurement in the first place.
+
+## Research and evaluation implications
+
+Alcove Dux should distinguish between:
+
+- observed evidence in documents
+- reviewer interpretations of that evidence
+- self-reported AI use by students or instructors
+
+Those are not interchangeable.
+
+In practice, that means:
+
+- do not advertise self-reported AI-use rates as a benchmark truth source
+- document when a dataset relies on disclosure or survey answers
+- prefer artifact-linked evaluation where possible
+- note that policy and stigma can shift reported usage without changing underlying behavior
+
+## Recommended stance
+
+Alcove Dux should continue to position itself as a local-first review aid for contested authorship and similarity questions, not as a confession extractor or automated misconduct judge.
+
+The paper supports that posture strongly.

--- a/docs/research.md
+++ b/docs/research.md
@@ -86,3 +86,7 @@ LLM paraphrase is in scope, but `LLM detector` branding is intentionally avoided
 - [TEIMMA: The First Content Reuse Annotator for Text, Images, and Math](https://arxiv.org/abs/2305.13193)
 - [Testing of Support Tools for Plagiarism Detection](https://arxiv.org/abs/2002.04279)
 - [Analyzing Non-Textual Content Elements to Detect Academic Plagiarism](https://arxiv.org/abs/2106.05764)
+## Related measurement note
+
+- [AI-use stigma, underreporting, and what it means for Alcove Dux](research-ai-use-stigma.md)
+

--- a/tests/test_research_ai_use_stigma_doc.py
+++ b/tests/test_research_ai_use_stigma_doc.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+DOC = Path(__file__).resolve().parents[1] / "docs" / "research-ai-use-stigma.md"
+README = Path(__file__).resolve().parents[1] / "README.md"
+RESEARCH = Path(__file__).resolve().parents[1] / "docs" / "research.md"
+
+
+def test_stigma_doc_exists_and_has_core_sections():
+    text = DOC.read_text(encoding="utf-8")
+    assert "AI-use stigma, underreporting" in text
+    assert "Why this matters for Alcove Dux" in text
+    assert "Product implications" in text
+    assert "Research and evaluation implications" in text
+    assert "confession extractor" in text
+
+
+def test_readme_links_to_stigma_doc():
+    text = README.read_text(encoding="utf-8")
+    assert "docs/research-ai-use-stigma.md" in text
+
+
+def test_research_notes_link_to_stigma_doc():
+    text = RESEARCH.read_text(encoding="utf-8")
+    assert "research-ai-use-stigma.md" in text


### PR DESCRIPTION
## Summary
- add a design memo on AI-use stigma and self-report bias for Alcove Dux
- link the memo from the README and research notes
- add focused coverage for the new docs surface

## Testing
- python3 -m pytest tests/test_research_ai_use_stigma_doc.py -q

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new research note about how self-reported AI use can be biased in high-stigma settings, with practical guidance for interpreting evidence and presenting findings more carefully.
  * Linked the new note from the main README and research index for easier discovery.
* **Tests**
  * Added coverage to ensure the new documentation page and its links remain present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->